### PR TITLE
Create ignore files only if there are suppressed classes/methods

### DIFF
--- a/modernizer-annotation-processor/src/main/java/org/gaul/modernizer_annotation_processor/ModernizerAnnotationProcessor.java
+++ b/modernizer-annotation-processor/src/main/java/org/gaul/modernizer_annotation_processor/ModernizerAnnotationProcessor.java
@@ -128,6 +128,9 @@ public class ModernizerAnnotationProcessor extends AbstractProcessor {
         File file,
         List<String> annotatedElements
     ) {
+        if (annotatedElements.isEmpty()) {
+            return;
+        }
         Writer writer = null;
         try {
             writer = new BufferedWriter(new FileWriter(file));


### PR DESCRIPTION
This PR adds a check which creates ignore files in `/target` directory only if there are classes/methods annotated with `@SuppressWarnings("modernizer")`

@stevegutz 